### PR TITLE
cpff_invert_contract command line argument parsing

### DIFF
--- a/cpff_invert_contract.cpp
+++ b/cpff_invert_contract.cpp
@@ -119,7 +119,12 @@ int main(int argc, char **argv) {
   while ((c = getopt(argc, argv, "ch?f:")) != -1) {
     switch (c) {
     case 'f':
-      strcpy(filename, optarg);
+      if( strlen(optarg) == 0 || strlen(optarg) >= 99){
+        printf("Passed -f option with empty string or string exceeding 99 characters!");
+        fflush(stdout); 
+        EXIT(222);
+      }
+      snprintf(filename, 100, "%s", optarg);
       filename_set=1;
       break;
     case 'c':


### PR DESCRIPTION
safeguard against really annoying error which potentially causes difficult to trace segmentation fault